### PR TITLE
Add a MAIN function around the mainline code

### DIFF
--- a/ascii_header_printer.007
+++ b/ascii_header_printer.007
@@ -265,4 +265,6 @@ export func printHeader(string) {
     }
 }
 
-printHeader("HELLO WORLD");
+func MAIN() {
+    printHeader("HELLO WORLD");
+}


### PR DESCRIPTION
This places the code atop [this feature](https://github.com/masak/007/issues/405).

Elevator pitch: when the same file could be alternately used as a module (using `import`) or as a top-level script file, the `export` statements cover the former case, and `MAIN` covers the latter. More to the point, `MAIN` makes sure you're _not_ running script code when your file is pulled in as a module.

The diff (although very small) is best viewed [with the ?w=1 flag](https://github.com/claes-magnus/007-ascii-header-printer/pull/9/files?w=1).

There's another obvious improvement to this PR that can be made once we have [parameter defaults](https://github.com/masak/007/issues/259) in 007: not hard-coding the `"HELLO WORLD"` string. But this is the best we can do so far.